### PR TITLE
Add tag name transformer feature to new React adapter

### DIFF
--- a/example-project/component-library-react/src/main.tsx
+++ b/example-project/component-library-react/src/main.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import { setTagNameTransformer } from '@stencil/react-output-target/runtime';
+
+setTagNameTransformer((tagName: string) => tagName + '-modified');
+const App = lazy(() => import('./App'));
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/react/src/react/create-component.ts
+++ b/packages/react/src/react/create-component.ts
@@ -2,6 +2,7 @@ import type { EventName, Options } from '@lit/react';
 import { createComponent as createComponentWrapper, type ReactWebComponent, WebComponentProps } from '@lit/react';
 
 import type { RenderToString } from './ssr';
+import { tagNameTransformer } from './tagNameTransformer';
 
 // A key value map matching React prop names to event names.
 type EventNames = Record<string, EventName | string>;
@@ -18,6 +19,11 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
   if (typeof defineCustomElement !== 'undefined') {
     defineCustomElement();
   }
+
+  if (typeof tagNameTransformer === 'function') {
+    options.tagName = tagNameTransformer(options.tagName);
+  }
+
   return createComponentWrapper<I, E>(options);
 };
 

--- a/packages/react/src/react/index.ts
+++ b/packages/react/src/react/index.ts
@@ -1,2 +1,3 @@
 export type { EventName, Options } from '@lit/react';
 export { createComponent, createSSRComponent, type StencilReactComponent } from './create-component';
+export { setTagNameTransformer } from './tagNameTransformer';

--- a/packages/react/src/react/tagNameTransformer.ts
+++ b/packages/react/src/react/tagNameTransformer.ts
@@ -1,0 +1,6 @@
+type TagNameTransformer = (tagName: string) => string;
+
+export let tagNameTransformer: TagNameTransformer | undefined;
+export const setTagNameTransformer = (_tagNameTransformer: TagNameTransformer) => {
+  tagNameTransformer = _tagNameTransformer;
+};


### PR DESCRIPTION
Hier eine funktionierende Implementierung des Tag Name Transformers für den neuen React Adapter (der jetzt auf Lit basiert).

Das PR dient zu Archivzwecken, weil der TNT vermutlich nicht mehr zum Einsatz kommt, da die Funktionalität im Stencil Core weggefallen ist.